### PR TITLE
If redis fails to connect, defer to in-memory caching

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -712,36 +712,23 @@ class WP_Object_Cache {
 		$this->multisite = is_multisite();
 		$this->blog_prefix =  $this->multisite ? $blog_id . ':' : '';
 
-		if ( empty( $redis_server ) ) {
-			$redis_server = array( 'host' => '127.0.0.1', 'port' => 6379 );
-		}
+		if ( false === $redis_server ) {
+			$this->is_connected = false;
+		} else {
+			if ( empty( $redis_server ) ) {
+				$redis_server = array( 'host' => '127.0.0.1', 'port' => 6379 );
+			}
 
-		$this->redis = new Redis();
-		$this->is_connected = $this->redis->connect( $redis_server['host'], $redis_server['port'], 2 ); # 2s timeout
-		if ( $this->is_connected && ! empty( $redis_server['auth'] ) ) {
-			$this->redis->auth( $redis_server['auth'] );
+			$this->redis = new Redis();
+			$this->is_connected = $this->redis->connect( $redis_server['host'], $redis_server['port'], 2 ); # 2s timeout
+			if ( $this->is_connected && ! empty( $redis_server['auth'] ) ) {
+				$this->redis->auth( $redis_server['auth'] );
+			}
 		}
 
 		$this->global_prefix = '';
 		if ( function_exists( 'is_multisite' ) ) {
 			$this->global_prefix = ( is_multisite() || defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) ) ? '' : $table_prefix;
 		}
-
-		/**
-		 * @todo This should be moved to the PHP4 style constructor, PHP5
-		 * already calls __destruct()
-		 */
-		register_shutdown_function( array( $this, '__destruct' ) );
-	}
-
-	/**
-	 * Will save the object cache before object is completely destroyed.
-	 *
-	 * Called upon object destruction, which should be when PHP ends.
-	 *
-	 * @return bool True value. Won't be used by PHP
-	 */
-	function __destruct() {
-		return true;
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,9 @@
 <?php
 
 $_tests_dir = getenv('WP_TESTS_DIR');
-if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
 
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
Also, boosting the timeout to 2s and dropping the 100ms timeout param. After usage in a heavy traffic environment, these proved to be better defaults. It might be worth making these options at some point.
