### PR TITLE
Support connecting to a Redis socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Setup
 1. Install `object-cache.php` to the `wp-content/object-cache.php`.
 2. In your `wp-config.php` file, add your server credentials:
 
-        $redis_server = array( 'host' => '127.0.0.1', 'port' => 6379, 'auth' => '12345' );
+  ```
+  $redis_server = array( 'host' => '127.0.0.1', 'port' => 6379, 'auth' => '12345' );
+  ```
 
-        or
+  or
 
-        $redis_server = array( 'socket' => '/tmp/redis.sock' );
+  ```
+  $redis_server = array( 'socket' => '/tmp/redis.sock' );
+  ```
 
 3. Optionally, add a unique salt for the keys:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Setup
 
         $redis_server = array( 'host' => '127.0.0.1', 'port' => 6379, 'auth' => '12345' );
 
+        or
+
+        $redis_server = array( 'socket' => '/tmp/redis.sock' );
+
 3. Optionally, add a unique salt for the keys:
 
         define( 'WP_CACHE_KEY_SALT', 'my-unique-phrase' );

--- a/object-cache.php
+++ b/object-cache.php
@@ -700,7 +700,13 @@ class WP_Object_Cache {
 		}
 
 		$this->redis = new Redis();
-		$this->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 ); # 1s timeout, 100ms delay between reconnections
+
+		if ( isset( $redis_server['socket'] ) ) {
+			$this->redis->connect( $redis_server['socket'] );
+		else {
+			$this->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 ); # 1s timeout, 100ms delay between reconnections
+		}
+
 		if ( ! empty( $redis_server['auth'] ) ) {
 			$this->redis->auth( $redis_server['auth'] );
 		}

--- a/object-cache.php
+++ b/object-cache.php
@@ -703,6 +703,7 @@ class WP_Object_Cache {
 
 		if ( isset( $redis_server['socket'] ) ) {
 			$this->redis->connect( $redis_server['socket'] );
+		}
 		else {
 			$this->redis->connect( $redis_server['host'], $redis_server['port'], 1, NULL, 100 ); # 1s timeout, 100ms delay between reconnections
 		}


### PR DESCRIPTION
We wanted the option to connect to a Redis socket, in addition to the TCP port.  Defaults remain the same, and passing in an array with `'host'` and `'port'` set still works, but now you can pass in `'socket'` and connect to the socket.  

Example:

```
$redis_server = array( 'socket' => '/tmp/redis.sock' );
```

Hopefully someone else finds this useful, thanks!
